### PR TITLE
fix: tighten docker networking defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ health: ## Check service health status
 	@curl -f http://localhost:${BACKEND_HOST_PORT:-8081}/api/modules > /dev/null 2>&1 && echo "$(GREEN)✓ Backend is healthy$(RESET)" || echo "$(YELLOW)✗ Backend is unhealthy$(RESET)"
 	@echo ""
 	@echo "$(BLUE)Frontend Health:$(RESET)"
-	@curl -f http://localhost:${FRONTEND_PORT:-3000}/ > /dev/null 2>&1 && echo "$(GREEN)✓ Frontend is healthy$(RESET)" || echo "$(YELLOW)✗ Frontend is unhealthy$(RESET)"
+	@curl -f http://localhost:${FRONTEND_HOST_PORT:-8080}/ > /dev/null 2>&1 && echo "$(GREEN)✓ Frontend is healthy$(RESET)" || echo "$(YELLOW)✗ Frontend is unhealthy$(RESET)"
 
 status: health ## Alias for 'make health'
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
       - ./.env:/app/.env:rw
 
     ports:
-      - "${BACKEND_HOST_PORT:-8081}:80"
+      - "127.0.0.1:${BACKEND_HOST_PORT:-8081}:80"
 
     # Development environment variables
     environment:
@@ -92,7 +92,7 @@ services:
       - BACKEND_URL=http://backend:80
 
     ports:
-      - "${HOST_PORT:-8080}:3000"
+      - "${FRONTEND_HOST_PORT:-8080}:3000"
 
     # Override command for development with hot-reload
     command: npm run dev

--- a/docker-compose.esphome.yml
+++ b/docker-compose.esphome.yml
@@ -1,15 +1,9 @@
 # Overrides applied when ESPHOME_PROXY_MODE=true
 services:
-  backend:
-    network_mode: host
-    ports: []
-    networks: []
-    environment:
-      - PORT=${BACKEND_HOST_PORT:-8081}
-
   frontend:
     network_mode: host
     ports: []
     networks: []
     environment:
       - BACKEND_URL=http://127.0.0.1:${BACKEND_HOST_PORT:-8081}
+      - PORT=${FRONTEND_HOST_PORT:-8080}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     # Publish the API to the host so the frontend (bridge networking by default) can proxy without
     # an intermediate reverse-proxy container. Override BACKEND_HOST_PORT if needed.
     ports:
-      - "${BACKEND_HOST_PORT:-8081}:80"
+      - "127.0.0.1:${BACKEND_HOST_PORT:-8081}:80"
 
     # Network
     networks:
@@ -114,7 +114,7 @@ services:
       - PORT=${FRONTEND_PORT:-3000}
 
     ports:
-      - "${FRONTEND_PORT:-3000}:3000"
+      - "${FRONTEND_HOST_PORT:-8080}:3000"
 
     # Resource limits
     deploy:


### PR DESCRIPTION
## Summary
- bind the backend container to `127.0.0.1:${BACKEND_HOST_PORT}` so it stays bridge-only and inaccessible from remote clients
- publish the frontend on `${FRONTEND_HOST_PORT:-8080}` by default and keep host networking confined to the frontend when ESPHome proxy mode is enabled
- update the ESPHome override, dev compose, and Makefile health check to route all backend traffic through the frontend proxy while preserving the local-only backend endpoint

## Testing
- docker compose up -d
- docker compose down
- docker compose up -d (verifies healthy stack)
- curl http://localhost:8080
- curl http://localhost:8081/api/modules (works locally)
- verify backend port is bound to 127.0.0.1 only via `docker compose ps`
