### PR TITLE
Fix Appwrite build compatibility

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -94,8 +94,8 @@
                 "typescript-eslint": "^8.46.3"
             },
             "engines": {
-                "node": ">=24.11.0",
-                "npm": ">=11.6.1"
+                "node": ">=22.21.1",
+                "npm": ">=10.9.4"
             }
         },
         "node_modules/@alloc/quick-lru": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
     "website": "https://nextjs-16-starter-shadcn.vercel.app/",
     "license": "MIT",
     "engines": {
-        "node": ">=24.11.0",
-        "npm": ">=11.6.1"
+        "node": ">=22.21.1",
+        "npm": ">=10.9.4"
     },
     "scripts": {
         "dev": "next dev --turbopack",
@@ -82,7 +82,6 @@
         "@faker-js/faker": "^10.1.0",
         "@next/bundle-analyzer": "16.0.1",
         "@next/eslint-plugin-next": "16.0.1",
-        "@tailwindcss/postcss": "^4.1.16",
         "@trivago/prettier-plugin-sort-imports": "^6.0.0",
         "@types/node": "^24.10.0",
         "@types/react": "19.2.2",
@@ -94,6 +93,7 @@
         "eslint-plugin-promise": "^7.2.1",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.5.0",
+        "@tailwindcss/postcss": "^4.1.16",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.7.1",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,3 +1,4 @@
+@source "../**/*.{ts,tsx}";
 @import "tailwindcss";
 
 @plugin "tailwindcss-animate";


### PR DESCRIPTION
## Summary
- lower the declared Node/npm engine requirements to match the Appwrite runner image (22.21.1/10.9.4)
- add a Tailwind @source directive so production builds emit utilities

## Testing
- npm run build