### PR TITLE
fix: Correct node-appwrite InputFile import path

### DIFF
--- a/.github/workflows/deploy-appwrite.yml
+++ b/.github/workflows/deploy-appwrite.yml
@@ -196,7 +196,7 @@ jobs:
           # Create deployment using Sites API
           node << 'EOF'
           const sdk = require('node-appwrite');
-          const { InputFile } = require('node-appwrite/inputFile');
+          const { InputFile } = require('node-appwrite/file');
           const fs = require('fs');
           
           const client = new sdk.Client()


### PR DESCRIPTION
Fixes GitHub Actions deployment failure.

**Issue**: `require('node-appwrite/inputFile')` throws ERR_PACKAGE_PATH_NOT_EXPORTED

**Fix**: Changed to `require('node-appwrite/file')` per package.json exports

This will allow Appwrite Sites deployment to succeed.