### PR TITLE
fix: Correct deployment path - remove frontend/ subdirectory

### DIFF
--- a/.github/workflows/deploy-appwrite.yml
+++ b/.github/workflows/deploy-appwrite.yml
@@ -165,12 +165,12 @@ jobs:
           echo "📦 Packaging Next.js standalone build..."
 
           # Create deployment structure
-          # Next.js standalone output structure:
-          # .next/standalone/frontend/  <- Contains server.js and .next/ directory
-          # .next/static/               <- CSS, JS chunks (needs to be copied into standalone)
-          # public/                     <- Static assets (needs to be copied into standalone)
+          # Next.js standalone output when building from frontend/ directory:
+          # .next/standalone/           <- Contains server.js (already flat since working-directory is frontend/)
+          # .next/static/               <- CSS, JS chunks (needs to be copied in)
+          # public/                     <- Static assets (needs to be copied in)
           #
-          # Appwrite Sites expects server.js at the ROOT level, so we need to flatten:
+          # Appwrite Sites deployment structure:
           # deploy/
           #   ├── server.js
           #   ├── .next/
@@ -179,9 +179,8 @@ jobs:
 
           mkdir -p deploy
 
-          # Copy standalone output FROM frontend subdirectory (flatten structure)
-          # This puts server.js at the root level where Appwrite expects it
-          cp -r .next/standalone/frontend/* deploy/
+          # Copy standalone output (already flat since we're building from frontend/ directory)
+          cp -r .next/standalone/* deploy/
 
           # Copy static assets into .next/static directory
           mkdir -p deploy/.next/static
@@ -192,6 +191,9 @@ jobs:
 
           echo "📋 Verifying deployment structure..."
           ls -la deploy/
+          echo ""
+          echo "✓ server.js present:"
+          ls -l deploy/server.js
           echo ""
           echo ".next directory:"
           ls -la deploy/.next/


### PR DESCRIPTION
## Problem

The deployment workflow failed with:
```
cp: cannot stat '.next/standalone/frontend/*': No such file or directory
```

## Root Cause

The workflow has `working-directory: frontend`, which means it builds **from inside** the frontend directory. When building from inside `frontend/`, Next.js standalone creates a **flat** structure:

```
.next/standalone/
  ├── server.js       ← Root level
  ├── .next/
  └── node_modules/
```

NOT:
```
.next/standalone/
  └── frontend/       ← Extra nesting only when building from repo root
      ├── server.js
      └── .next/
```

## Fix

Changed packaging step from:
```bash
cp -r .next/standalone/frontend/* deploy/  # Wrong - no frontend/ subdirectory exists
```

To:
```bash
cp -r .next/standalone/* deploy/  # Correct - matches actual structure
```

## Testing

This should fix the deployment failure and allow the workflow to:
1. ✅ Copy standalone files correctly
2. ✅ Add static assets to `.next/static/`
3. ✅ Package and deploy to Appwrite Sites
4. ✅ Serve CSS and JS files with 200 OK (not 404)

Fixes the issue from PR #75