### PR TITLE
fix: enable Poetry 2.x export in Appwrite Function deployment

### DIFF
--- a/.github/workflows/deploy-appwrite-function.yml
+++ b/.github/workflows/deploy-appwrite-function.yml
@@ -12,6 +12,7 @@ name: Deploy Backend to Appwrite Function
 # - Auto-scaling
 # - Custom domain: api.sfplib.com
 # - Environment variables configured in Appwrite Console
+# - requirements.txt generated dynamically from pyproject.toml (Poetry 2.x compatible)
 #
 # This runs independently from Sites deployment
 # Frontend calls backend via /api/* rewrites to api.sfplib.com
@@ -82,11 +83,20 @@ jobs:
             exit 1
           fi
 
-          # Create requirements.txt from Poetry for Appwrite
+          # Install Poetry
+          echo "Installing Poetry..."
           pip install poetry
-          poetry export -f requirements.txt --output requirements.txt --without-hashes
+
+          # Install poetry-plugin-export (required for Poetry 2.x)
+          echo "Installing poetry-plugin-export for Poetry 2.x compatibility..."
+          poetry self add poetry-plugin-export
+
+          # Generate requirements.txt from Poetry
+          echo "Generating requirements.txt from pyproject.toml..."
+          poetry export -f requirements.txt --output requirements.txt --without-hashes --without dev
 
           echo "✅ Backend prepared"
+          echo "requirements.txt size: $(wc -l < requirements.txt) lines"
           ls -la
 
       - name: Deploy Function
@@ -208,8 +218,9 @@ jobs:
              - \`APPWRITE_API_KEY\`
              - \`APPWRITE_FUNCTION_ID\` (create in Console first)
           3. Verify function exists in Appwrite Console
-          4. Check Poetry dependencies in pyproject.toml
+          4. Check Poetry dependencies in backend/pyproject.toml
           5. Ensure Python 3.12 runtime is available
+          6. If poetry export fails, verify poetry.lock is up-to-date
 
           ### Create Function Manually
           If function doesn't exist:


### PR DESCRIPTION
This commit fixes the "The requested command export does not exist" error by properly installing the poetry-plugin-export plugin.

Root Cause:
- Poetry 2.x moved the `export` command to a separate plugin
- The workflow was trying to run `poetry export` without the plugin installed
- This caused deployment failures

Solution:
1. Install poetry-plugin-export with `poetry self add poetry-plugin-export`
2. Generate requirements.txt dynamically from pyproject.toml during deployment
3. No need for static requirements.txt in repo (keeps dependencies fresh)

Changes:
- Added `poetry self add poetry-plugin-export` step before export
- Generate requirements.txt on-the-fly from current pyproject.toml
- Updated workflow comments to reflect dynamic generation
- Cleaned up troubleshooting docs

Benefits:
- Always uses latest dependencies from pyproject.toml
- No risk of stale static requirements.txt
- Works with both Poetry 1.x and 2.x
- Proper solution for active development

Tested against Poetry 2.2.1 (current version in the error log).

## Summary
Describe the change.

## Motivation
Why is this change needed?

## Changes
- [ ] Frontend
- [ ] Backend
- [ ] Docs
- [ ] CI/Config

## Testing
Steps to verify the change locally.

## Screenshots / Logs
If applicable.

## Checklist
- [ ] I updated documentation where needed
- [ ] I tested locally with `docker-compose up --build`
- [ ] I added TODOs for follow-up work where appropriate
