### PR TITLE
fix: make ESPHome imports conditional to prevent Appwrite deployment …

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from app.api.v1 import esphome, esphome_websocket, health, modules, submissions, esphome_status
+from app.api.v1 import health, modules, submissions, esphome_status
 from app.config import get_settings
 
 api_router = APIRouter()
@@ -24,6 +24,8 @@ if settings.ha_addon_mode:
     api_router.include_router(ha_bluetooth.router, tags=["ha-bluetooth"])
 elif settings.esphome_proxy_mode:
     # Standalone mode with ESPHome proxy
+    # Import ESPHome modules only when needed (they require zeroconf)
+    from app.api.v1 import esphome, esphome_websocket
     # Always include ESPHome status endpoint (reports enabled/disabled)
     api_router.include_router(esphome_status.router, tags=["esphome"])
     api_router.include_router(esphome.router, tags=["esphome-proxy"])

--- a/backend/app/services/esphome/proxy_manager.py
+++ b/backend/app/services/esphome/proxy_manager.py
@@ -3,9 +3,20 @@
 import asyncio
 import logging
 from typing import Dict, Optional, Callable
-from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
-from zeroconf.asyncio import AsyncZeroconf
 
+# Optional zeroconf dependency (only needed for ESPHome proxy mode)
+try:
+    from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
+    from zeroconf.asyncio import AsyncZeroconf
+    ZEROCONF_AVAILABLE = True
+except ImportError:
+    ZEROCONF_AVAILABLE = False
+    ServiceBrowser = None  # type: ignore
+    ServiceStateChange = None  # type: ignore
+    Zeroconf = None  # type: ignore
+    AsyncZeroconf = None  # type: ignore
+
+# Optional aioesphomeapi dependency (only needed for ESPHome proxy mode)
 try:
     from aioesphomeapi import APIClient, APIConnectionError
     ESPHOME_AVAILABLE = True
@@ -27,6 +38,10 @@ class ProxyManager:
         if not ESPHOME_AVAILABLE:
             raise ImportError(
                 "aioesphomeapi not installed. Install with: pip install aioesphomeapi"
+            )
+        if not ZEROCONF_AVAILABLE:
+            raise ImportError(
+                "zeroconf not installed. Install with: pip install zeroconf"
             )
 
         self.proxies: Dict[str, ESPHomeProxy] = {}


### PR DESCRIPTION
…failures

**Problem:**
Appwrite Functions don't install optional dependencies (zeroconf, aioesphomeapi). Unconditional imports were causing ModuleNotFoundError on deployment, even when ESPHOME_PROXY_MODE=false.

**Root Cause:**
- router.py imported esphome modules at module level (line 5)
- proxy_manager.py imported zeroconf without try/except protection
- Imports executed even when ESPHome mode disabled

**Solution:**
1. Move ESPHome imports to conditional block in router.py
   - Only import when settings.esphome_proxy_mode=true
   - Prevents import chain to optional dependencies

2. Add protective try/except for zeroconf in proxy_manager.py
   - Mirrors existing pattern from connection_manager.py
   - Sets ZEROCONF_AVAILABLE flag for runtime checks
   - Raises ImportError in __init__ if not available

**Testing:**
- Verified no unconditional imports of optional deps across codebase
- Confirmed connection_manager.py already has aioesphomeapi protection
- All __init__.py files are clean (no imports)
- Only router.py imports from app.api.v1 (now fixed)

**Impact:**
- Appwrite deployment: No optional deps imported (both modes false)
- Standalone mode: Works unchanged (deps installed via Docker)
- ESPHome mode: Works unchanged (deps in requirements.txt)

Fixes the 500 errors preventing frontend-backend communication in Appwrite.

## Summary
Describe the change.

## Motivation
Why is this change needed?

## Changes
- [ ] Frontend
- [ ] Backend
- [ ] Docs
- [ ] CI/Config

## Testing
Steps to verify the change locally.

## Screenshots / Logs
If applicable.

## Checklist
- [ ] I updated documentation where needed
- [ ] I tested locally with `docker-compose up --build`
- [ ] I added TODOs for follow-up work where appropriate
