### PR TITLE
fix: add ingress path support and fix PWA manifest for HA add-on

### DIFF
--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -17,5 +17,5 @@
   "theme_color": "#1E88E5",
   "background_color": "#ffffff",
   "display": "standalone",
-  "start_url": "/"
+  "start_url": "."
 }

--- a/sfpliberate/Dockerfile
+++ b/sfpliberate/Dockerfile
@@ -104,7 +104,7 @@ LABEL \
     io.hass.description="Bluetooth companion for Ubiquiti SFP Wizard" \
     io.hass.arch="aarch64|amd64|armhf|armv7" \
     io.hass.type="addon" \
-    io.hass.version="1.0.0" \
+    io.hass.version="0.2.0" \
     maintainer="Josiah Nelson <https://github.com/josiah-nelson>" \
     org.opencontainers.image.title="SFPLiberate" \
     org.opencontainers.image.description="Bluetooth companion for Ubiquiti SFP Wizard" \

--- a/sfpliberate/run.sh
+++ b/sfpliberate/run.sh
@@ -15,6 +15,9 @@ export HASSIO_TOKEN="${SUPERVISOR_TOKEN}"
 export HA_API_URL="http://supervisor/core/api"
 export HA_WS_URL="ws://supervisor/core/websocket"
 
+# Ingress path handling
+export INGRESS_PATH="${INGRESS_ENTRY:-}"
+
 # Add-on specific paths
 export DATABASE_FILE="/config/sfpliberate/sfp_library.db"
 export SUBMISSIONS_DIR="/config/sfpliberate/submissions"


### PR DESCRIPTION
- Add INGRESS_PATH environment variable in run.sh for proper asset routing via Home Assistant's ingress proxy
- Fix site.webmanifest start_url to use relative path (".") instead of "/" to prevent redirects to HA root when accessed via ingress

These changes ensure the add-on works correctly when accessed through Home Assistant's ingress system while maintaining proper PWA functionality.

## Summary
Describe the change.

## Motivation
Why is this change needed?

## Changes
- [ ] Frontend
- [ ] Backend
- [ ] Docs
- [ ] CI/Config

## Testing
Steps to verify the change locally.

## Screenshots / Logs
If applicable.

## Checklist
- [ ] I updated documentation where needed
- [ ] I tested locally with `docker-compose up --build`
- [ ] I added TODOs for follow-up work where appropriate
