### PR TITLE
Fix Home Assistant add-on config schema validation

### DIFF
--- a/homeassistant/config.yaml
+++ b/homeassistant/config.yaml
@@ -55,8 +55,7 @@ options:
 schema:
   log_level: list(debug|info|warning|error)
   auto_discover: bool
-  device_name_patterns: 
-    - str
+  device_name_patterns: list(str)
   connection_timeout: int(10,120)
   device_expiry_seconds: int(60,3600)
   scan_interval: int(1,60)


### PR DESCRIPTION
## Problem
The add-on was not appearing in the Home Assistant add-on store after adding the repository due to config.yaml schema validation errors.

Home Assistant logs showed:
- Schema validation errors for all option descriptions
- Warning about deprecated `codenotary` field

## Solution
- Fixed schema format to use simple type definitions instead of nested objects with name/description/type
- Removed deprecated `codenotary` field
- Options still work correctly with defaults specified in `options` section

## Testing
After this change, the add-on should appear in HA add-on store when the repository URL is added.

Fixes the issue where HA supervisor rejected the config with:
```
does not match regular expression ^(?:|bool|email|url|port|device...) for dictionary value @ data['schema']['*']['description']
```