### PR TITLE
Fix Appwrite Sites deployment: use standalone server start command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
         "dev": "next dev --turbopack",
         "build": "next build --turbopack",
         "postbuild": "cp -r .next/static .next/standalone/.next/static && if [ -d public ]; then cp -r public .next/standalone/public; fi",
-        "start": "next start",
+        "start": "node .next/standalone/server.js",
         "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
         "lint:fix": "eslint --fix \"src/**/*.{js,jsx,ts,tsx}\"",
         "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",


### PR DESCRIPTION
## Problem
The Appwrite Sites deployment at https://app.sfplib.com/ is showing "Internal Server Error" because the start command is incorrect.

## Root Cause
- Next.js `standalone` output mode generates a `.next/standalone/server.js` file
- Appwrite Sites runs `npm start` after building
- Current start script uses `next start` which expects the full Next.js output structure
- For standalone mode, must use `node .next/standalone/server.js` directly

## Solution
Changed package.json start script from:
```json
"start": "next start"
```

To:
```json
"start": "node .next/standalone/server.js"
```

## Testing
After merge, Appwrite's Git Auto-Deploy will:
1. Build the standalone output
2. Run `npm start` which now correctly executes the standalone server
3. Site should load at https://app.sfplib.com/

## References
- Next.js standalone output: https://nextjs.org/docs/app/api-reference/config/next-config-js/output
- Appwrite Sites uses npm scripts for deployment lifecycle