### PR TITLE
Fix Appwrite Sites deployment: support APPWRITE_SITE_* env vars

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -28,6 +28,8 @@ const withBundleAnalyzer = initializeBundleAnalyzer({
  * - Zero code divergence between modes
  */
 const isAppwriteSite = !!(
+    process.env.APPWRITE_SITE_API_ENDPOINT ||
+    process.env.APPWRITE_SITE_PROJECT_ID ||
     process.env.APPWRITE_FUNCTION_API_ENDPOINT ||
     process.env.APPWRITE_FUNCTION_PROJECT_ID ||
     process.env.APPWRITE_ENDPOINT ||

--- a/frontend/src/lib/features.ts
+++ b/frontend/src/lib/features.ts
@@ -15,11 +15,13 @@ export type DeploymentMode = 'standalone' | 'appwrite';
  * Get Appwrite endpoint (cloud only)
  *
  * Checks multiple sources in order of precedence:
- * 1. APPWRITE_FUNCTION_API_ENDPOINT (auto-injected by Appwrite Functions)
- * 2. APPWRITE_ENDPOINT (custom env var)
+ * 1. APPWRITE_SITE_API_ENDPOINT (auto-injected by Appwrite Sites)
+ * 2. APPWRITE_FUNCTION_API_ENDPOINT (auto-injected by Appwrite Functions)
+ * 3. APPWRITE_ENDPOINT (custom env var)
  */
 export function getAppwriteEndpoint(): string | undefined {
-  return process.env.APPWRITE_FUNCTION_API_ENDPOINT ||
+  return process.env.APPWRITE_SITE_API_ENDPOINT ||
+         process.env.APPWRITE_FUNCTION_API_ENDPOINT ||
          process.env.APPWRITE_ENDPOINT;
 }
 
@@ -27,11 +29,13 @@ export function getAppwriteEndpoint(): string | undefined {
  * Get Appwrite project ID (cloud only)
  *
  * Checks multiple sources in order of precedence:
- * 1. APPWRITE_FUNCTION_PROJECT_ID (auto-injected by Appwrite Functions)
- * 2. APPWRITE_PROJECT_ID (custom env var)
+ * 1. APPWRITE_SITE_PROJECT_ID (auto-injected by Appwrite Sites)
+ * 2. APPWRITE_FUNCTION_PROJECT_ID (auto-injected by Appwrite Functions)
+ * 3. APPWRITE_PROJECT_ID (custom env var)
  */
 export function getAppwriteProjectId(): string | undefined {
-  return process.env.APPWRITE_FUNCTION_PROJECT_ID ||
+  return process.env.APPWRITE_SITE_PROJECT_ID ||
+         process.env.APPWRITE_FUNCTION_PROJECT_ID ||
          process.env.APPWRITE_PROJECT_ID;
 }
 
@@ -44,6 +48,8 @@ export function getAppwriteProjectId(): string | undefined {
 export function getDeploymentMode(): DeploymentMode {
   // Check for Appwrite-injected or custom variables
   const hasAppwriteVars = !!(
+    process.env.APPWRITE_SITE_API_ENDPOINT ||
+    process.env.APPWRITE_SITE_PROJECT_ID ||
     process.env.APPWRITE_FUNCTION_API_ENDPOINT ||
     process.env.APPWRITE_FUNCTION_PROJECT_ID ||
     process.env.APPWRITE_ENDPOINT ||
@@ -171,10 +177,10 @@ export function validateEnvironment(): {
   // Validate Appwrite configuration (only if in Appwrite mode)
   if (mode === 'appwrite') {
     if (!getAppwriteEndpoint()) {
-      errors.push('APPWRITE_FUNCTION_API_ENDPOINT (auto-injected) or APPWRITE_ENDPOINT is missing');
+      errors.push('APPWRITE_SITE_API_ENDPOINT, APPWRITE_FUNCTION_API_ENDPOINT, or APPWRITE_ENDPOINT is missing');
     }
     if (!getAppwriteProjectId()) {
-      errors.push('APPWRITE_FUNCTION_PROJECT_ID (auto-injected) or APPWRITE_PROJECT_ID is missing');
+      errors.push('APPWRITE_SITE_PROJECT_ID, APPWRITE_FUNCTION_PROJECT_ID, or APPWRITE_PROJECT_ID is missing');
     }
     // API URL is always /api (unified pattern), no validation needed
   }


### PR DESCRIPTION
## Problem
The Appwrite Sites deployment at https://app.sfplib.com/ shows "Internal Server Error" because the application can't find required Appwrite configuration.

## Root Cause
Appwrite provides different environment variables for **Sites** vs **Functions**:
- **Appwrite Sites** auto-injects: `APPWRITE_SITE_API_ENDPOINT` and `APPWRITE_SITE_PROJECT_ID`
- **Appwrite Functions** auto-inject: `APPWRITE_FUNCTION_API_ENDPOINT` and `APPWRITE_FUNCTION_PROJECT_ID`

Our code was only checking for the Function variables, causing it to fail on Sites.

## Solution
Updated both `features.ts` and `next.config.ts` to check for Appwrite Sites variables first:

Now checks in this order:
1. APPWRITE_SITE_API_ENDPOINT or APPWRITE_SITE_PROJECT_ID (Sites)
2. APPWRITE_FUNCTION_API_ENDPOINT or APPWRITE_FUNCTION_PROJECT_ID (Functions)
3. APPWRITE_ENDPOINT or APPWRITE_PROJECT_ID (custom env vars)

## Changes
- Updated `getAppwriteEndpoint()` to check SITE variables first
- Updated `getAppwriteProjectId()` to check SITE variables first  
- Updated `getDeploymentMode()` to detect Sites correctly
- Updated `next.config.ts` isAppwriteSite detection
- Updated error messages to reflect all supported variables
- Maintains backward compatibility with Functions and custom vars

## Testing
After merge, Appwrite Git Auto-Deploy will:
1. Build with `APPWRITE_SITE_*` variables available
2. Correctly detect Appwrite deployment mode
3. Initialize Appwrite client with proper endpoint and project ID
4. Site should load successfully at https://app.sfplib.com/

## References
- Appwrite Sites env vars: https://appwrite.io/docs/products/sites/environment-variables
- Previous working commit: Before PR #102 merge