### PR TITLE
Debug: Add logging to diagnose Appwrite Sites rewrites error

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -63,25 +63,23 @@ const nextConfig: NextConfig = {
     },
 
     // Rewrites for standalone/HA modes only (Appwrite uses native SDK)
-    // Standalone/HA modes proxy /api/* to their respective backends
+    // Returns undefined for Appwrite mode (no rewrites configuration)
     async rewrites() {
+        // Log deployment mode for debugging
+        console.log(`[Next.js Config] Deployment mode: ${deploymentMode}`);
+        console.log(`[Next.js Config] Appwrite detection - SITE_API: ${!!process.env.APPWRITE_SITE_API_ENDPOINT}, SITE_PROJECT: ${!!process.env.APPWRITE_SITE_PROJECT_ID}, ENDPOINT: ${!!process.env.APPWRITE_ENDPOINT}, PROJECT: ${!!process.env.APPWRITE_PROJECT_ID}`);
+        
         // Appwrite mode doesn't need API rewrites (uses native SDK)
         if (isAppwrite) {
+            console.log(`[Next.js Config] Appwrite mode - returning empty rewrites`);
             return [];
         }
 
         // Determine backend URL based on deployment mode
-        let backendUrl: string;
+        const backendUrl = isHomeAssistant
+            ? 'http://localhost:80'  // HA add-on
+            : (process.env.BACKEND_URL || 'http://backend:80');  // Standalone
 
-        if (isHomeAssistant) {
-            // HA add-on: backend runs on localhost:80
-            backendUrl = 'http://localhost:80';
-        } else {
-            // Standalone: backend is Docker service on bridge network
-            backendUrl = process.env.BACKEND_URL || 'http://backend:80';
-        }
-
-        console.log(`[Next.js Config] Deployment mode: ${deploymentMode}`);
         console.log(`[Next.js Config] Backend URL: ${backendUrl}`);
 
         return [


### PR DESCRIPTION
## Problem
Appwrite Sites deployment shows "Invalid URL" error in rewrites() function.

## Error Details
```
TypeError: Invalid URL
at parseDestination (prepare-destination.js:149:43)
```

## Hypothesis
The env vars (`APPWRITE_SITE_*`) might not be available at **build time** when `next.config.ts` is evaluated, only at **runtime**. This would cause:
1. `isAppwrite` = false during build
2. Tries to construct `backendUrl` with invalid values
3. Next.js fails to parse the destination URL

## This PR
Adds extensive debug logging to see:
- Which env vars are present during build
- What deployment mode is detected
- Whether the Appwrite early return is triggered

## Next Steps
After merging, check Appwrite build logs for the console.log output to confirm which env vars are available and when.