### PR TITLE
fix: use any for Appwrite realtime subscription type

### DIFF
--- a/frontend/src/components/modules/ModulesTable.tsx
+++ b/frontend/src/components/modules/ModulesTable.tsx
@@ -58,8 +58,7 @@ export function ModulesTable({ initialData }: ModulesTableProps) {
   // Realtime updates in Appwrite mode
   useEffect(() => {
     if (!isAppwrite()) return;
-    type RealtimeSubscription = import('appwrite').RealtimeSubscription;
-    let subscription: RealtimeSubscription | undefined;
+    let subscription: any;
     (async () => {
       try {
         const { Realtime } = await import('appwrite');
@@ -91,7 +90,10 @@ export function ModulesTable({ initialData }: ModulesTableProps) {
       }
     })();
     return () => {
-      try { subscription?.unsubscribe(); } catch {}
+      try {
+        if (subscription?.unsubscribe) subscription.unsubscribe();
+        else if (subscription?.close) subscription.close();
+      } catch {}
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Fixes the Docker frontend build failure caused by a TypeScript error in `ModulesTable.tsx`. The `appwrite` package does not export RealtimeSubscription, so the import was removed and the subscription type was updated to match ModuleTable.tsx.

## Motivation
`docker compose up --build` failed during the frontend build with:

`Type error: Namespace '"/app/node_modules/appwrite/types/index"' has no exported member 'RealtimeSubscription'.`

This blocked local development and deployment of the standalone Docker setup.

## Changes
- [x] Frontend
- [ ] Backend
- [ ] Docs
- [ ] CI/Config

## Testing

1. `cd` into the repo root
2. Run `docker compose up --build`
3. Confirm the frontend build finishes and containers start

## Screenshots / Logs
If applicable.

## Checklist
- [x] I updated documentation where needed
- [x] I tested locally with `docker-compose up --build`
- [x] I added TODOs for follow-up work where appropriate
