### PR TITLE
Remove -ci from version string for Home Assistant to comply with semver

### DIFF
--- a/.github/workflows/ha-addon-build.yml
+++ b/.github/workflows/ha-addon-build.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           python3 homeassistant/build.py \
             --arch ${{ matrix.arch }} \
-            --tag "${VERSION}-ci" \
+            --tag "${VERSION}" \
             --registry ghcr.io/${{ github.repository_owner }} \
             --image sfpliberate-addon-{arch} \
             --push


### PR DESCRIPTION
## Summary
When publishing a new version of the Home Assistant image, a semver was calculated, but "-ci" was appended. This caused a mismatch with the version in config.yaml causing Home Assisstant not being able to find the right image.

Based on config.yaml Home Assistant tried to download hcr.io/josiah-nelson/sfpliberate-addon-aarch64:0.2.0, but the version published is called hcr.io/josiah-nelson/sfpliberate-addon-aarch64:0.2.0-ci

This PR changes the build to a clean semver "0.2.0"

## Motivation
Home Assistant can't install without this fix. Fixes #118 

## Changes
- [ ] Frontend
- [ ] Backend
- [ ] Docs
- [X] CI/Config

## Testing
It's a proposed change to the github workflow, so I can't test it fully.

## Screenshots / Logs
```
[33m2026-04-07 16:13:42.317 WARNING (MainThread) [supervisor.docker.manifest] Failed to fetch manifest for ghcr.io/josiah-nelson/sfpliberate-addon-aarch64:0.2.0 - 404[0m
[32m2026-04-07 16:13:42.318 INFO (MainThread) [supervisor.docker.interface] Downloading docker image ghcr.io/josiah-nelson/sfpliberate-addon-aarch64 with tag 0.2.0.[0m
[31m2026-04-07 16:13:43.146 ERROR (MainThread) [supervisor.docker.interface] Can't install ghcr.io/josiah-nelson/sfpliberate-addon-aarch64:0.2.0: [404] manifest unknown[0m
[31m2026-04-07 16:13:43.147 ERROR (MainThread) [supervisor.addons.addon] Could not pull image to update addon ee5cc9ed_sfpliberate: Can't install ghcr.io/josiah-nelson/sfpliberate-addon-aarch64:0.2.0: [404] manifest unknown[0m
```

## Checklist
- [ ] I updated documentation where needed
- [ ] I tested locally with `docker-compose up --build`
- [ ] I added TODOs for follow-up work where appropriate
